### PR TITLE
Add compile-time option to not use malloc/free

### DIFF
--- a/libpressf.pri
+++ b/libpressf.pri
@@ -1,5 +1,6 @@
 SOURCES += \
     $$PWD/src/debug.c \
+    $$PWD/src/dma.c \
     $$PWD/src/emu.c \
     $$PWD/src/font.c \
     $$PWD/src/hle.c \
@@ -24,6 +25,7 @@ SOURCES += \
 HEADERS += \
     $$PWD/src/config.h \
     $$PWD/src/debug.h \
+    $$PWD/src/dma.h \
     $$PWD/src/emu.h \
     $$PWD/src/font.h \
     $$PWD/src/hle.h \

--- a/src/config.h
+++ b/src/config.h
@@ -87,6 +87,25 @@ PF_STATIC_ASSERT(!(PF_SOUND_FREQUENCY % 60),
 #endif
 
 /**
+ * When set, the program is compiled without using dynamic memory allocation
+ * via malloc/free. The program in this state will instead use a static
+ * fixed-size heap, shared between all emulator instances. Use only if
+ * absolutely necessary, such as on very limited embedded platforms.
+ *
+ * Requires PF_ROMC to be FALSE and a heap size (in bytes) must be
+ * defined as PRESS_F_NO_DMA_SIZE.
+ */
+#ifndef PF_NO_DMA
+#define PF_NO_DMA FALSE
+#else
+#if !defined(PF_NO_DMA_SIZE) || PF_NO_DMA_SIZE <= 0
+#error "Static heap size not specified (define PF_NO_DMA_SIZE)."
+#elif PF_ROMC
+#error "PF_ROMC must be defined as FALSE if using no DMA."
+#endif
+#endif
+
+/**
  * Controls whether or not to emulate ROMC functions.
  * Not emulating ROMC allows for using simpler instruction sets, but removes
  * some functionality.

--- a/src/dma.c
+++ b/src/dma.c
@@ -1,0 +1,61 @@
+#include "dma.h"
+
+void pf_dma_oom_cb_default(void)
+{
+  exit(1);
+}
+
+#if PF_NO_DMA
+static u8 pf_heap[PF_NO_DMA_SIZE];
+static unsigned pf_heap_alloc = 0;
+static void (*pf_dma_oom_cb)(void) = pf_dma_oom_cb_default;
+#endif
+
+void *pf_dma_alloc(unsigned size, unsigned zero)
+{
+/**
+ * Implements very simple DMA for embedded systems that have no access to
+ * malloc. Uses a static-sized heap, allocates purely linearly, and does not
+ * actually free values. Use only if absolutely necessary.
+ */
+#if PF_NO_DMA
+  if (size + pf_heap_alloc >= PF_NO_DMA_SIZE)
+  {
+    pf_dma_oom_cb();
+    return NULL;
+  }
+  else
+  {
+    u8 *allocated_value = &pf_heap[pf_heap_alloc];
+
+    if (zero)
+    {
+      unsigned offset;
+
+      for (offset = pf_heap_alloc; offset < pf_heap_alloc + size; offset++)
+        pf_heap[offset] = 0;
+    }
+    pf_heap_alloc += size;
+
+    return allocated_value;
+  }
+#else
+  return zero ? calloc(size, 1) : malloc(size);
+#endif
+}
+
+void pf_dma_free(void *value)
+{
+#if PF_NO_DMA
+  F8_UNUSED(value);
+#else
+  free(value);
+#endif
+}
+
+void pf_dma_set_oom_cb(void *cb)
+{
+  pf_dma_oom_cb = cb;
+}
+
+#endif

--- a/src/dma.c
+++ b/src/dma.c
@@ -9,6 +9,8 @@ void pf_dma_oom_cb_default(void)
 static u8 pf_heap[PF_NO_DMA_SIZE];
 static unsigned pf_heap_alloc = 0;
 static void (*pf_dma_oom_cb)(void) = pf_dma_oom_cb_default;
+#else
+#include <stdlib.h>
 #endif
 
 void *pf_dma_alloc(unsigned size, unsigned zero)

--- a/src/dma.c
+++ b/src/dma.c
@@ -1,13 +1,15 @@
 #include "dma.h"
 
-void pf_dma_oom_cb_default(void)
-{
-  exit(1);
-}
-
 #if PF_NO_DMA
 static u8 pf_heap[PF_NO_DMA_SIZE];
 static unsigned pf_heap_alloc = 0;
+
+void pf_dma_oom_cb_default(void)
+{
+  printf("Out of memory error! (%u of %u)\n", pf_heap_alloc, PF_NO_DMA_SIZE);
+  exit(1);
+}
+
 static void (*pf_dma_oom_cb)(void) = pf_dma_oom_cb_default;
 #else
 #include <stdlib.h>
@@ -23,7 +25,9 @@ void *pf_dma_alloc(unsigned size, unsigned zero)
 #if PF_NO_DMA
   if (size + pf_heap_alloc >= PF_NO_DMA_SIZE)
   {
-    pf_dma_oom_cb();
+    if (pf_dma_oom_cb)
+      pf_dma_oom_cb();
+
     return NULL;
   }
   else
@@ -57,7 +61,9 @@ void pf_dma_free(void *value)
 
 void pf_dma_set_oom_cb(void *cb)
 {
+#if PF_NO_DMA
   pf_dma_oom_cb = cb;
-}
-
+#else
+  F8_UNUSED(cb);
 #endif
+}

--- a/src/dma.h
+++ b/src/dma.h
@@ -7,4 +7,6 @@ void *pf_dma_alloc(unsigned size, unsigned zero);
 
 void pf_dma_free(void *value);
 
+void pf_dma_set_oom_cb(void *cb);
+
 #endif

--- a/src/dma.h
+++ b/src/dma.h
@@ -1,0 +1,10 @@
+#ifndef PRESS_F_DMA_H
+#ifndef PRESS_F_DMA_H
+
+#include "config.h"
+
+void *pf_dma_alloc(unsigned size, unsigned zero);
+
+void pf_dma_free(void *value);
+
+#endif

--- a/src/dma.h
+++ b/src/dma.h
@@ -1,5 +1,5 @@
 #ifndef PRESS_F_DMA_H
-#ifndef PRESS_F_DMA_H
+#define PRESS_F_DMA_H
 
 #include "config.h"
 

--- a/src/emu.c
+++ b/src/emu.c
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "debug.h"

--- a/src/emu.c
+++ b/src/emu.c
@@ -1405,7 +1405,6 @@ u8 pressf_init(f8_system_t *system)
   {
     memset(system, 0, sizeof(f8_system_t));
     f8_settings_apply_default(system);
-    f3850_init(&system->f8devices[0]);
 
     return TRUE;
   }

--- a/src/hw/2102.c
+++ b/src/hw/2102.c
@@ -1,8 +1,4 @@
-#ifndef PRESS_F_2102_C
-#define PRESS_F_2102_C
-
-#include <stdlib.h>
-#include <string.h>
+#include "../dma.h"
 
 #include "2102.h"
 
@@ -93,7 +89,7 @@ void f2102_init(f8_device_t *device)
      return;
    else
    {
-     f2102_t *m_f2102 = (f2102_t*)calloc(sizeof(f2102_t), 1);
+     f2102_t *m_f2102 = (f2102_t*)pf_dma_alloc(sizeof(f2102_t), TRUE);
      device->device = m_f2102;
      device->data = m_f2102->data;
      device->name = name;
@@ -123,5 +119,3 @@ void f2102_unserialize(void *buffer, unsigned size, unsigned *offset, f8_device_
   *offset += sizeof(f2102_t);
   */
 }
-
-#endif

--- a/src/hw/3850.c
+++ b/src/hw/3850.c
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include "../dma.h"
 
 #include "3850.h"
 
@@ -9,7 +9,7 @@ void f3850_init(f8_device_t *device)
 {
   if (device)
   {
-    device->device = (f3850_t*)calloc(sizeof(f3850_t), 1);
+    device->device = (f3850_t*)pf_dma_alloc(sizeof(f3850_t), TRUE);
     device->name = name;
     device->type = type;
 

--- a/src/hw/beeper.c
+++ b/src/hw/beeper.c
@@ -1,5 +1,4 @@
-#include <stdlib.h>
-
+#include "../dma.h"
 #include "../wave.h"
 
 #include "beeper.h"
@@ -107,7 +106,7 @@ void beeper_init(f8_device_t *device)
 #endif
   if (device)
   {
-    device->device = (f8_beeper_t*)calloc(1, sizeof(f8_beeper_t));
+    device->device = (f8_beeper_t*)pf_dma_alloc(sizeof(f8_beeper_t), TRUE);
     device->name = name;
     device->type = type;
     device->flags = F8_NO_ROMC;

--- a/src/hw/f8_device.c
+++ b/src/hw/f8_device.c
@@ -26,14 +26,12 @@ void f8_generic_unserialize(f8_device_t *device, const void *buffer, unsigned *s
 
 void f8_generic_init(f8_device_t *device, unsigned size)
 {
-#if PF_ROMC
   if (device)
   {
-    device->data = pf_dma_alloc(size);
+    /* Only allocate if mot using fixed memory map */
+#if PF_ROMC
+    device->data = pf_dma_alloc(size, FALSE);
+#endif
     device->length = size;
   }
-#else
-  F8_UNUSED(device);
-  F8_UNUSED(size);
-#endif
 }

--- a/src/hw/f8_device.c
+++ b/src/hw/f8_device.c
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include "../dma.h"
 
 #include "f8_device.h"
 
@@ -28,7 +28,7 @@ void f8_generic_init(f8_device_t *device, unsigned size)
 {
   if (device)
   {
-    device->data = malloc(size);
+    device->data = pf_dma_alloc(size);
     device->length = size;
   }
 }

--- a/src/hw/f8_device.c
+++ b/src/hw/f8_device.c
@@ -26,9 +26,14 @@ void f8_generic_unserialize(f8_device_t *device, const void *buffer, unsigned *s
 
 void f8_generic_init(f8_device_t *device, unsigned size)
 {
+#if PF_ROMC
   if (device)
   {
     device->data = pf_dma_alloc(size);
     device->length = size;
   }
+#else
+  F8_UNUSED(device);
+  F8_UNUSED(size);
+#endif
 }

--- a/src/hw/hand_controller.c
+++ b/src/hw/hand_controller.c
@@ -1,6 +1,6 @@
-#include <stdlib.h>
-
+#include "../dma.h"
 #include "../input.h"
+
 #include "hand_controller.h"
 
 static const char *name = "Hand-Controller";
@@ -39,7 +39,7 @@ void hand_controller_init(f8_device_t *device)
 {
   if (device)
   {
-    device->device = (f8_hand_controller_t*)malloc(sizeof(f8_hand_controller_t));
+    device->device = (f8_hand_controller_t*)pf_dma_alloc(sizeof(f8_hand_controller_t), FALSE);
     device->name = name;
     device->type = type;
     device->flags = F8_NO_ROMC;

--- a/src/hw/vram.c
+++ b/src/hw/vram.c
@@ -1,7 +1,6 @@
 #include "vram.h"
+#include "../dma.h"
 #include "../screen.h"
-
-#include <stdlib.h>
 
 static const char *name = "VRAM";
 static const int type = F8_DEVICE_MK4027;
@@ -53,7 +52,7 @@ void vram_init(f8_device_t *device)
 {
   if (device)
   {
-    device->device = (vram_t*)malloc(sizeof(vram_t));
+    device->device = (vram_t*)pf_dma_alloc(sizeof(vram_t), FALSE);
     device->name = name;
     device->type = type;
     device->flags = F8_NO_ROMC;


### PR DESCRIPTION
The intent of this option is to support more embedded platforms in the future, which may not have access to stdlib memory management functions

- Adds the PF_NO_DMA and PF_NO_DMA_SIZE compile-time options
- Implements simple fixed-size heap management for when these options are set
- Replaces all instances of malloc/calloc with custom implementation
- Fixes accidental double-allocate when PF_ROMC is FALSE

Closes #1 